### PR TITLE
Ensure activity log sorts by recent library events

### DIFF
--- a/libraryLogic.d.ts
+++ b/libraryLogic.d.ts
@@ -1,0 +1,49 @@
+export interface IssueRecord {
+  id: string;
+  qrCode: string;
+  employeeId: string;
+  employeeName: string;
+  designation: string;
+  bookTitle: string;
+  issueDate: Date;
+  dueDate: Date;
+  returnDate?: Date;
+  status: "issued" | "returned";
+  bookImage?: string;
+}
+
+export interface IssueInput {
+  qrCode: string;
+  employeeId: string;
+  bookTitle: string;
+  bookImage?: string | null;
+}
+
+export interface EmployeeInfo {
+  name: string;
+  designation: string;
+}
+
+export type EmployeeDirectory = Record<string, EmployeeInfo>;
+
+export type IssueOutcome =
+  | { kind: "success"; record: IssueRecord; message: string }
+  | { kind: "error"; message: string };
+
+export type ReturnOutcome =
+  | { kind: "success"; record: IssueRecord; records: IssueRecord[]; message: string }
+  | { kind: "error"; message: string };
+
+export declare const ISSUE_DURATION_DAYS: number;
+export declare function sortRecordsByActivity(records: IssueRecord[]): IssueRecord[];
+export declare function issueBook(
+  currentRecords: IssueRecord[],
+  input: IssueInput,
+  employees: EmployeeDirectory,
+  options?: { now?: Date },
+): IssueOutcome;
+export declare function returnBook(
+  currentRecords: IssueRecord[],
+  qrCode: string,
+  options?: { now?: Date },
+): ReturnOutcome;

--- a/libraryLogic.js
+++ b/libraryLogic.js
@@ -1,0 +1,161 @@
+export const ISSUE_DURATION_DAYS = 15;
+
+const addDays = (date, days) => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+const toTimestamp = (value) => {
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
+  }
+  return 0;
+};
+
+const getActivityTimestamp = (record) => {
+  return toTimestamp(record.returnDate ?? record.issueDate);
+};
+
+const getIssueTimestamp = (record) => {
+  return toTimestamp(record.issueDate);
+};
+
+export const sortRecordsByActivity = (records) => {
+  return [...records].sort((a, b) => {
+    const activityDiff = getActivityTimestamp(b) - getActivityTimestamp(a);
+    if (activityDiff !== 0) {
+      return activityDiff;
+    }
+
+    const aReturned = Boolean(a.returnDate);
+    const bReturned = Boolean(b.returnDate);
+    if (aReturned !== bReturned) {
+      return bReturned ? 1 : -1;
+    }
+
+    return getIssueTimestamp(b) - getIssueTimestamp(a);
+  });
+};
+
+export const issueBook = (currentRecords, input, employees, options = {}) => {
+  const now = options.now ?? new Date();
+  const trimmedQr = input.qrCode.trim();
+  const trimmedEmployeeId = input.employeeId.trim().toUpperCase();
+  const trimmedBookTitle = input.bookTitle.trim();
+
+  if (!trimmedQr) {
+    return {
+      kind: "error",
+      message: "Please scan or enter a QR code for the book.",
+    };
+  }
+
+  if (!trimmedEmployeeId) {
+    return {
+      kind: "error",
+      message: "Employee ID is required to issue a book.",
+    };
+  }
+
+  const employee = employees[trimmedEmployeeId];
+
+  if (!employee) {
+    return {
+      kind: "error",
+      message: "No employee record found for the provided ID.",
+    };
+  }
+
+  if (!trimmedBookTitle) {
+    return {
+      kind: "error",
+      message: "Please provide the book title before issuing.",
+    };
+  }
+
+  if (!input.bookImage) {
+    return {
+      kind: "error",
+      message: "Please capture and upload the book image.",
+    };
+  }
+
+  const alreadyIssued = currentRecords.some(
+    (record) => record.qrCode === trimmedQr && record.status === "issued",
+  );
+
+  if (alreadyIssued) {
+    return {
+      kind: "error",
+      message: "This QR code is already associated with an active book issue.",
+    };
+  }
+
+  const issueDate = new Date(now);
+  const dueDate = addDays(issueDate, ISSUE_DURATION_DAYS);
+
+  const record = {
+    id: `${issueDate.getTime()}-${Math.random().toString(36).slice(2, 8)}`,
+    qrCode: trimmedQr,
+    employeeId: trimmedEmployeeId,
+    employeeName: employee.name,
+    designation: employee.designation,
+    bookTitle: trimmedBookTitle,
+    issueDate,
+    dueDate,
+    status: "issued",
+    bookImage: input.bookImage,
+  };
+
+  return {
+    kind: "success",
+    record,
+    message: `${record.bookTitle} issued to ${record.employeeName}. Due on ${dueDate.toDateString()}.`,
+  };
+};
+
+export const returnBook = (currentRecords, qrCode, options = {}) => {
+  const trimmedQr = qrCode.trim();
+
+  if (!trimmedQr) {
+    return {
+      kind: "error",
+      message: "Please scan or enter the book's QR code.",
+    };
+  }
+
+  const now = options.now ?? new Date();
+
+  const index = currentRecords.findIndex(
+    (record) => record.qrCode === trimmedQr && record.status === "issued",
+  );
+
+  if (index === -1) {
+    return {
+      kind: "error",
+      message: "No active issued book found for the scanned QR code.",
+    };
+  }
+
+  const updatedRecord = {
+    ...currentRecords[index],
+    status: "returned",
+    returnDate: new Date(now),
+  };
+
+  const updatedRecords = [...currentRecords];
+  updatedRecords[index] = updatedRecord;
+
+  return {
+    kind: "success",
+    record: updatedRecord,
+    records: sortRecordsByActivity(updatedRecords),
+    message: `${updatedRecord.bookTitle} returned successfully by ${updatedRecord.employeeName}.`,
+  };
+};
+

--- a/libraryLogic.test.mjs
+++ b/libraryLogic.test.mjs
@@ -1,0 +1,168 @@
+import {
+  ISSUE_DURATION_DAYS,
+  issueBook,
+  returnBook,
+  sortRecordsByActivity,
+} from "./libraryLogic.js";
+
+const employees = {
+  EMP001: { name: "Test User", designation: "Engineer" },
+};
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const addDays = (date, days) => {
+  const result = new Date(date);
+  result.setDate(result.getDate() + days);
+  return result;
+};
+
+(() => {
+  const now = new Date("2024-01-01T00:00:00Z");
+  const outcome = issueBook(
+    [],
+    {
+      qrCode: "QR-100",
+      employeeId: "emp001",
+      bookTitle: "Domain-Driven Design",
+      bookImage: "data:image/png;base64,test",
+    },
+    employees,
+    { now },
+  );
+
+  assert(outcome.kind === "success", "Expected successful issue");
+  if (outcome.kind === "success") {
+    assert(outcome.record.qrCode === "QR-100", "QR code mismatch");
+    assert(
+      outcome.record.dueDate.getTime() === addDays(now, ISSUE_DURATION_DAYS).getTime(),
+      "Due date should be 15 days after issue",
+    );
+  }
+})();
+
+(() => {
+  const now = new Date("2024-01-02T00:00:00Z");
+  const firstIssue = issueBook(
+    [],
+    {
+      qrCode: "QR-200",
+      employeeId: "EMP001",
+      bookTitle: "Clean Code",
+      bookImage: "img",
+    },
+    employees,
+    { now },
+  );
+
+  assert(firstIssue.kind === "success", "First issue should succeed");
+  const existingRecords = firstIssue.kind === "success" ? [firstIssue.record] : [];
+  const secondIssue = issueBook(
+    existingRecords,
+    {
+      qrCode: "QR-200",
+      employeeId: "EMP001",
+      bookTitle: "Clean Code",
+      bookImage: "img",
+    },
+    employees,
+    { now },
+  );
+
+  assert(secondIssue.kind === "error", "Duplicate issue should fail");
+})();
+
+(() => {
+  const now = new Date("2024-01-03T00:00:00Z");
+  const issueOutcome = issueBook(
+    [],
+    {
+      qrCode: "QR-300",
+      employeeId: "EMP001",
+      bookTitle: "Refactoring",
+      bookImage: "img",
+    },
+    employees,
+    { now },
+  );
+
+  assert(issueOutcome.kind === "success", "Issue should succeed before return");
+
+  const records = issueOutcome.kind === "success" ? [issueOutcome.record] : [];
+  const returnOutcome = returnBook(records, "QR-300", { now });
+
+  assert(returnOutcome.kind === "success", "Return should succeed");
+  if (returnOutcome.kind === "success") {
+    assert(returnOutcome.record.status === "returned", "Returned record should be marked as returned");
+    assert(returnOutcome.records[0].returnDate, "Return date should be populated");
+  }
+})();
+
+(() => {
+  const issuedAt = new Date("2024-01-05T09:00:00Z");
+  const laterActivity = new Date("2024-01-06T09:00:00Z");
+
+  const firstIssue = issueBook(
+    [],
+    {
+      qrCode: "QR-OLDER",
+      employeeId: "EMP001",
+      bookTitle: "Working Effectively with Legacy Code",
+      bookImage: "img",
+    },
+    employees,
+    { now: issuedAt },
+  );
+
+  const secondIssue = issueBook(
+    firstIssue.kind === "success" ? [firstIssue.record] : [],
+    {
+      qrCode: "QR-NEWER",
+      employeeId: "EMP001",
+      bookTitle: "Design Patterns",
+      bookImage: "img",
+    },
+    employees,
+    { now: laterActivity },
+  );
+
+  const currentRecords = secondIssue.kind === "success"
+    ? sortRecordsByActivity([secondIssue.record, ...(firstIssue.kind === "success" ? [firstIssue.record] : [])])
+    : [];
+
+  const returnOutcome = returnBook(currentRecords, "QR-OLDER", { now: laterActivity });
+
+  assert(returnOutcome.kind === "success", "Return should succeed");
+  if (returnOutcome.kind === "success") {
+    assert(
+      returnOutcome.records[0].qrCode === "QR-OLDER",
+      "Recently returned record should move to the top of the activity list",
+    );
+  }
+})();
+
+(() => {
+  const outcome = issueBook(
+    [],
+    {
+      qrCode: " ",
+      employeeId: "EMP001",
+      bookTitle: "Some Book",
+      bookImage: "img",
+    },
+    employees,
+  );
+
+  assert(outcome.kind === "error", "Blank QR should be rejected");
+})();
+
+(() => {
+  const outcome = returnBook([], "UNKNOWN");
+  assert(outcome.kind === "error", "Returning unknown QR should fail");
+})();
+
+console.log("All library logic tests passed");

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "library-issuing-system",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node libraryLogic.test.mjs"
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to order issue records by their most recent activity
- keep the home activity feed sorted when issuing or returning books
- extend the logic tests to cover the new ordering behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d63ff1249c833384fcba2ae3d3f626